### PR TITLE
add additional fields to the gelf forwarding

### DIFF
--- a/src/controller.go
+++ b/src/controller.go
@@ -89,6 +89,8 @@ func (c *Controller) log(event *core.Event) {
 			"kind":           event.InvolvedObject.Kind,
 			"namespace_name": event.InvolvedObject.Namespace,
 			"pod_name":       event.InvolvedObject.Name,
+			"event_type":     event.Type,
+			"event_reason":   event.Reason,
 		},
 	}
 


### PR DESCRIPTION
* event.Type: usually reflects the seriousness of the event (e.g. Normal,
  Warning)
* event.Reason: a machine parseable key for the event. This will be key for
  searching within graylog.