### PR TITLE
Handle event updates

### DIFF
--- a/src/controller.go
+++ b/src/controller.go
@@ -80,7 +80,7 @@ func (c *Controller) log(event *core.Event) {
 		Level:    mapEventTypeToGelfLevel(event),
 		Host:     c.host,
 		Short:    event.Message,
-		TimeUnix: float64(event.CreationTimestamp.Unix()),
+		TimeUnix: float64(event.LastTimestamp.Unix()),
 		Extra: map[string]interface{}{
 			"cluster":        c.cluster,
 			"component":      event.Source.Component,


### PR DESCRIPTION
Currently we do not handle updated events. These are events that occur multiple times before the timeout removes the resources from etcd. This is tracked on the resource by incrementing the `Count` field and updating the `LastTimestamp` field.